### PR TITLE
Add setWebhook call upon start

### DIFF
--- a/main.go
+++ b/main.go
@@ -106,8 +106,18 @@ func setupBot() {
 		log.Fatal("Bot setup error")
 	}
 	log.Printf("Bot username is: %s", info["username"].(string))
-	hookPath := path.Join("https://", conf.BaseDomain, conf.HookPath)
+	hookPath := "https://" + path.Join(conf.BaseDomain, conf.HookPath)
 	log.Println("Hook expected on: ", hookPath)
+
+	go func() {
+		time.Sleep(2 * time.Second)
+		ok := bot.SetWebhook(hookPath)
+		if ok {
+			log.Println("Bot setWebhook: ok")
+		} else {
+			log.Fatal("Bot setWebhook: error")
+		}
+	}()
 }
 
 /* Creates xmpp connection

--- a/telegrambot/bot.go
+++ b/telegrambot/bot.go
@@ -116,8 +116,9 @@ func (bot *Bot) Command(cmd string,
 			result["description"].(string))
 		serverResponse.description = result["description"].(string)
 	} else {
-		st := result["result"].(map[string]interface{})
-		serverResponse.result = BotResult(st)
+		if st, exists := result["result"].(map[string]interface{}); exists {
+			serverResponse.result = BotResult(st)
+		}
 	}
 	return serverResponse
 }
@@ -139,4 +140,14 @@ func (bot *Bot) SendMessage(chat_id int, text string) int {
 		return int(msg_id.(float64))
 	}
 	return 0
+}
+
+func (bot *Bot) SetWebhook(hookurl string) bool {
+	values := url.Values{}
+	values.Set("url", hookurl)
+	resp := bot.Command("setWebhook", &values)
+	if resp != nil && resp.ok {
+		return true
+	}
+	return false
 }


### PR DESCRIPTION
When starting the bot, a call to to telegram setting the defined webhook is made.
I'm just learning go, so maybe there is a better method to execute the call after the server has started than to wait a short period `time.Sleep(2 * time.Second)`.

How is your status in general about the project? Is it still under development or abandoned?
